### PR TITLE
Dev and bug fixes

### DIFF
--- a/include/Eval.h
+++ b/include/Eval.h
@@ -15,12 +15,12 @@
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  This program is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
@@ -44,7 +44,7 @@ namespace eval
 	    double emax;
 	    double index;
 	};
-	
+
 	class Mapspec : public std::vector<MapspecEntry>
 	{
 	public:
@@ -70,7 +70,7 @@ namespace eval
 	                 double emax, double fovradmin, double fovradmax,
 	                 const char *selectionFilename, const char *templateFilename,
 	                 Intervals &intervals, std::vector< std::vector<double> > &exposures,
-	                 bool saveMaps);
+	                 bool saveMaps, bool sum_exposure, std::vector<double> &summed_exposures);
 
 	int EvalCounts(const char *outfile, const char *projection, double tmin,
 	               double tmax, double mdim, double mres, double la, double ba,

--- a/src/Eval.cpp
+++ b/src/Eval.cpp
@@ -337,9 +337,9 @@ int EvalExposure(const char *outfile, const char *sarFileName,
 
     long mxdim = long(mdim / mres + 0.1); // dimension (in pixels) of the map
 
-#ifdef DEBUG
+//#ifdef DEBUG
     cout << "mdim: " << mdim << " mres: " << mres << " mxdim: " << mxdim << " nmaps: " << nmaps << endl;
-#endif
+//#endif
     long npixels = mxdim * mxdim;
     exposures.resize(intervals.Count());
     for (int i=0; i < intervals.Count(); i++) {
@@ -724,13 +724,33 @@ int EvalExposure(const char *outfile, const char *sarFileName,
 
     }
 
+    double pixel1 = DEG2RAD * DEG2RAD * fabs(mdim * mdim);
+    double areapixel =  pixel1 * Sinaa(DEG2RAD*45.);
+    
+    if(mxdim == 1)
+    {
+      for (long long m=0; m<nmaps; m++) {
 
-    if(sum_exposure)
+
+        summed_exposures.resize(npixels);
+
+        for (unsigned int j=0; j<npixels; j++)
+            summed_exposures[j] = 0;
+
+
+        for (int intvIndex=0; intvIndex<intervals.Count(); intvIndex++)
+          for (unsigned int j=0; j<npixels; j++)
+            summed_exposures[j] += exposures[intvIndex][m * npixels + j]/areapixel;
+
+      }
+    }
+    else if(sum_exposure)
     {
 
       float center_x = mxdim / 2 - 0.5;
       float center_y = mxdim / 2 - 0.5;
       float radius_of_circle = mxdim/2;
+
 
       #ifdef DEBUG
       cout << "mdim: " << mdim << " mres: " << mres << " mxdim: " << mxdim << " nmaps: " << nmaps << endl;
@@ -752,11 +772,9 @@ int EvalExposure(const char *outfile, const char *sarFileName,
 
 
         for (int intvIndex=0; intvIndex<intervals.Count(); intvIndex++)
-        {
-
           for (unsigned int j=0; j<npixels; j++)
-            sum[j] += exposures[intvIndex][m * npixels + j];
-        }
+            sum[j] += exposures[intvIndex][m * npixels + j]/areapixel;
+
 
 
 

--- a/src/Eval.cpp
+++ b/src/Eval.cpp
@@ -725,11 +725,13 @@ int EvalExposure(const char *outfile, const char *sarFileName,
       float center_y = mxdim / 2 - 0.5;
       float radius_of_circle = mxdim/2;
 
+      #ifdef DEBUG
       cout << "mdim: " << mdim << " mres: " << mres << " mxdim: " << mxdim << " nmaps: " << nmaps << endl;
       cout << "radius_of_circle: " << radius_of_circle << endl;
       cout << "center: " << center_x << " " << center_y << endl;
       cout << "intervals count: " << intervals.Count() << endl;
-
+      cout << "npixels: " << npixels << endl;
+      #endif
 
       for (long long m=0; m<nmaps; m++) {
 
@@ -741,10 +743,15 @@ int EvalExposure(const char *outfile, const char *sarFileName,
         for (unsigned int j=0; j<npixels; j++)
             sum[j] = 0;
 
-        for (int intvIndex=0; intvIndex<intervals.Count(); intvIndex++)
 
-            for (unsigned int j=0; j<npixels; j++)
-                sum[j] += exposures[intvIndex][m * npixels + j];
+        for (int intvIndex=0; intvIndex<intervals.Count(); intvIndex++)
+        {
+
+          for (unsigned int j=0; j<npixels; j++)
+            sum[j] += exposures[intvIndex][m * npixels + j];
+        }
+
+
 
         for (int y = 0; y < mxdim; y++) {
           for (int x = 0; x < mxdim; x++) {
@@ -755,7 +762,7 @@ int EvalExposure(const char *outfile, const char *sarFileName,
             float dist = sqrt( pow(center_x - x, 2) + pow(center_y - y, 2) );
 
             if (dist <= radius_of_circle){
-              double pixel_exp = sum[m*npixels + x*mxdim + y];
+              double pixel_exp = sum[x*mxdim + y];
               //cout << x << "," << y << " = " << pixel_exp << endl;
               summed_exposure += pixel_exp;
 
@@ -766,8 +773,12 @@ int EvalExposure(const char *outfile, const char *sarFileName,
         summed_exposures.push_back(summed_exposure);
       }
 
+      int map_ind = 0;
       for (std::vector<double>::iterator it = summed_exposures.begin() ; it != summed_exposures.end(); ++it)
-        cout << "summed exp: " << *it << endl;
+      {
+        cout << "Exposure summed for map "<<map_ind<< " in a radius of "<< radius_of_circle << " degrees = " <<*it << endl;
+        map_ind ++;
+      }
     }
 
 

--- a/src/Eval.cpp
+++ b/src/Eval.cpp
@@ -801,7 +801,7 @@ int EvalExposure(const char *outfile, const char *sarFileName,
       int map_ind = 0;
       for (std::vector<double>::iterator it = summed_exposures.begin() ; it != summed_exposures.end(); ++it)
       {
-        cout << "Exposure summed for map "<<map_ind<< " in a radius of "<< radius_of_circle << " degrees = " <<*it << endl;
+        cout << "Exposure summed for map "<<map_ind<< " in a radius of "<< radius_of_circle*mres << " degrees = " <<*it << endl;
         map_ind ++;
       }
     }

--- a/src/Eval.cpp
+++ b/src/Eval.cpp
@@ -326,6 +326,13 @@ int EvalExposure(const char *outfile, const char *sarFileName,
         mapspec.index = index;
         maps.push_back(mapspec);
     }
+
+    // the pixel dimension must be lower than the map dimension
+    if(mres > mdim){
+      cout << "Eval.cpp error! The pixel dimension must be lower than the map dimension." << endl;
+      return 1;
+    }
+
     long nmaps = maps.size();
 
     long mxdim = long(mdim / mres + 0.1); // dimension (in pixels) of the map

--- a/src/Selection.cpp
+++ b/src/Selection.cpp
@@ -325,10 +325,12 @@ int MakeSelection(const char *fileList, Intervals& selection,
 
         //string sel_int = TimesExprString(sel);
         //cout << "sel_int: " << sel_int << endl;
-
+        //cout << "=> Number of intervals satisfied: " << sel.Count() << endl;
         for (int i=0; i<sel.Count() && !status; i++) {
             Intervals selInt;
             selInt.Add(sel[i]);
+
+            //cout << "selInt["<<i<<"]: " << TimesExprString(selInt) <<endl;
 
             // This is a bug fix
             if(sel.Count() > 1){
@@ -337,6 +339,9 @@ int MakeSelection(const char *fileList, Intervals& selection,
               // before:  ((TIME >= 181774800.000000 && TIME < 181861200.000000) || (TIME >= 182230000.000000 && TIME < 182450000.000000)) && ENERGY >= 100 && ENERGY <= 10000 && PH_EARTH > 80 && THETA < 60 && THETA >= 0 && PHASE .NE. 1 && PHASE .NE. 4 && EVSTATUS .NE. 'L' && EVSTATUS .NE. 'S'
               // after 1: ((TIME >= 181774800.000000 && TIME < 181861200.000000) && ENERGY >= 100 && ENERGY <= 10000 && PH_EARTH > 80 && THETA < 60 && THETA >= 0 && PHASE .NE. 1 && PHASE .NE. 4 && EVSTATUS .NE. 'L' && EVSTATUS .NE. 'S'
               // after 2: ((TIME >= 182230000.000000 && TIME < 182450000.000000)) && ENERGY >= 100 && ENERGY <= 10000 && PH_EARTH > 80 && THETA < 60 && THETA >= 0 && PHASE .NE. 1 && PHASE .NE. 4 && EVSTATUS .NE. 'L' && EVSTATUS .NE. 'S'
+            }
+            else {
+              expr = expr_backup;
             }
 
 


### PR DESCRIPTION
-  Added two new parameters to Eval.cpp::EvalExposure(): 
     * bool sum_exposure, 
     * std::vector<double> &summed_exposures
if sum_exposure = true, the function will sum up the exposure value of each pixel inside a circle (the exposure values are normalized dividing by the area of the pixel)

 - Fixed bug in Selection.cpp::MakeSelection. Duplicated photons were selected from the AGILE data when two time intervals could be fetched from the same AGILE data file. Now it is possible to use the time list feature.

- Added the mres <= mdim check in Eval.cpp 


TESTING:
- the pixel values of the cts and exp maps are equal comparing the old code with the new one.
- because of normalization by areapixel division, I cant compare anymore the results of the exposure summation procedure with old results, neither I can use ds9 to check the results.